### PR TITLE
Update backend qubit configuration check

### DIFF
--- a/circuit-training.ipynb
+++ b/circuit-training.ipynb
@@ -567,7 +567,7 @@
     "conn=2 #Connectivity of the entangler.\n",
     "\n",
     "#Check on qubit count\n",
-    "if n>backend.configuration().n_qubits:\n",
+    "if n>backend.num_qubits:\n",
     "    raise Exception(\"Too many qubits\")\n",
     "\n",
     "#Check on conn\n",


### PR DESCRIPTION
This step of the notebook fails, since Qiskit BackendV2 removed the configuration attribute. It now has a direct attribute for num_qubits, see [here](https://github.com/Qiskit/qiskit/blob/main/qiskit/providers/backend.py)

> This abstract class is to be used for all Backend objects created by a
>     provider. This version differs from earlier abstract Backend classes in
>     that the configuration attribute no longer exists. Instead, attributes
>     exposing equivalent required immutable properties of the backend device
>     are added. For example ``backend.configuration().n_qubits`` is accessible
>     from ``backend.num_qubits`` now.